### PR TITLE
LLAMA-17374: removing receiver ID

### DIFF
--- a/src/xr-speech-vrex/xrsv_http/xrsv_http.c
+++ b/src/xr-speech-vrex/xrsv_http/xrsv_http.c
@@ -40,7 +40,6 @@ typedef struct {
    void *               param;
    char                 query_element_trx[41];
    char                 query_element_device_id[64];
-   char                 query_element_receiver_id[64];
    char                 query_element_codec[17];
    char                 query_element_app_id[64];
    char                 query_element_partner_id[32];
@@ -88,9 +87,6 @@ xrsv_http_object_t xrsv_http_create(const xrsv_http_params_t *params) {
    
    if(params->device_id != NULL) {
       xrsv_http_update_device_id(obj, params->device_id);
-   }
-   if(params->receiver_id) {
-      xrsv_http_update_receiver_id(obj, params->receiver_id);
    }
    if(params->app_id != NULL) {
       xrsv_http_update_app_id(obj, params->app_id);
@@ -160,22 +156,6 @@ bool xrsv_http_update_device_id(xrsv_http_object_t object, const char *device_id
    int rc = snprintf(obj->query_element_device_id, sizeof(obj->query_element_device_id), "xboDeviceId=%s", device_id);
    if(rc >= sizeof(obj->query_element_device_id)) {
       XLOGD_WARN("truncated device id <%d>", rc);
-   } else {
-      rv = true;
-   }
-   return(rv);
-}
-
-bool xrsv_http_update_receiver_id(xrsv_http_object_t object, const char *receiver_id) {
-   xrsv_http_obj_t *obj = (xrsv_http_obj_t *)object;
-   if(!xrsv_http_object_is_valid(obj)) {
-      XLOGD_ERROR("invalid object");
-      return(false);
-   }
-   bool rv = false;
-   int rc = snprintf(obj->query_element_receiver_id, sizeof(obj->query_element_receiver_id), "receiverId=%s", receiver_id);
-   if(rc >= sizeof(obj->query_element_receiver_id)) {
-      XLOGD_WARN("truncated receiver id <%d>", rc);
    } else {
       rv = true;
    }
@@ -265,7 +245,6 @@ void xrsv_http_destroy(xrsv_http_object_t object) {
    XLOGD_INFO("");
 
    obj->query_element_device_id[0]     = '\0';
-   obj->query_element_receiver_id[0]   = '\0';
    obj->query_element_codec[0]         = '\0';
    obj->query_element_trx[0]           = '\0';
    obj->query_element_app_id[0]        = '\0';

--- a/src/xr-speech-vrex/xrsv_http/xrsv_http.h
+++ b/src/xr-speech-vrex/xrsv_http/xrsv_http.h
@@ -60,7 +60,6 @@
 /// @details The param data structure is used to provide input parameters to the xrsv_http_open() function.  All string parameters must be NULL-terminated.  If a string parameter is not present, NULL must be set for it.
 typedef struct {
    const char *device_id;        ///< The client device's unique identifier
-   const char *receiver_id;      ///< The client device's receiver identifier
    const char *partner_id;       ///< The network's partner identifier
    const char *experience;       ///< User experience identifier
    const char *app_id;           ///< The application identifier for HTTP requests from the client device


### PR DESCRIPTION
Reason for change:  We no longer support receiver ID, remove all references from the code

Test Procedure: just confirm it doesn't crash, this is code removal

 Risks: Low

 Priority: P1

Signed-off-by: Jason Thomson jason_thomson@comcast.com>