### PR TITLE
RDKEMW-7183 : Use Consolidated FFV KWD Repos in RDKV Voice SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ endif()
 if(XRAUDIO_KWD_ENABLED)
    target_compile_definitions(xr-voice-sdk PUBLIC XRAUDIO_KWD_ENABLED)
    target_link_libraries(xr-voice-sdk xraudio-ffv-hal)
-   target_link_libraries(xr-voice-sdk xraudio-kwd)
+   target_link_libraries(xr-voice-sdk xraudio-ffv-kwd)
 endif()
 
 if(XRAUDIO_EOS_ENABLED OR XRAUDIO_DGA_ENABLED OR XRAUDIO_PPR_ENABLED) 


### PR DESCRIPTION
Reason for change: Update voice sdk to use consolidated far-field voice keyword detector Gerrit repo.

Test Procedure: Refer to Jira ticket.

Priority: P2

Risks: Low

Signed-off-by: Gary Skrabutenas@comcast.com