### PR TITLE
RDKEMW-14445: add stream end reason and protocol code to session end

### DIFF
--- a/src/xr-speech-router/xrsr.c
+++ b/src/xr-speech-router/xrsr.c
@@ -3264,6 +3264,8 @@ bool xrsr_speech_stream_end(const uuid_t uuid, xrsr_src_t src, uint32_t dst_inde
 
    xrsr_session_t *session = &g_xrsr.sessions[xrsr_source_to_group(src)];
 
+   session->stats.stream_end_reason = reason;
+
    // Need to know when all streams have ended to call xraudio stream end?
    session->pipe_fds_rd[dst_index] = -1;
 

--- a/src/xr-speech-router/xrsr.c
+++ b/src/xr-speech-router/xrsr.c
@@ -3264,8 +3264,6 @@ bool xrsr_speech_stream_end(const uuid_t uuid, xrsr_src_t src, uint32_t dst_inde
 
    xrsr_session_t *session = &g_xrsr.sessions[xrsr_source_to_group(src)];
 
-   session->stats.stream_end_reason = reason;
-
    // Need to know when all streams have ended to call xraudio stream end?
    session->pipe_fds_rd[dst_index] = -1;
 

--- a/src/xr-speech-router/xrsr.h
+++ b/src/xr-speech-router/xrsr.h
@@ -384,7 +384,10 @@ typedef struct {
 /// @brief XRSR session stats structure
 /// @details The session statistics data structure indicates the statistics for an audio session.
 typedef struct {
-   xrsr_session_end_reason_t session_end_reason;                 ///< Reason why the session ended
+   union {
+      xrsr_session_end_reason_t session_end_reason;              ///< Reason why the session ended (preferred usage)
+      xrsr_session_end_reason_t reason;                          ///< Reason why the session ended (maintained alias for compatibility)
+   };
    xrsr_ret_code_internal_t  ret_code_internal;                  ///< Internal return code (speech router)
    long                      ret_code_protocol;                  ///< Protocol return code (HTTP, WS, etc)
    long                      ret_code_library;                   ///< Library return code (curl, nopoll, etc)

--- a/src/xr-speech-router/xrsr.h
+++ b/src/xr-speech-router/xrsr.h
@@ -384,13 +384,14 @@ typedef struct {
 /// @brief XRSR session stats structure
 /// @details The session statistics data structure indicates the statistics for an audio session.
 typedef struct {
-   xrsr_session_end_reason_t reason;                             ///< Reason why the session ended
+   xrsr_session_end_reason_t session_end_reason;                 ///< Reason why the session ended
    xrsr_ret_code_internal_t  ret_code_internal;                  ///< Internal return code (speech router)
    long                      ret_code_protocol;                  ///< Protocol return code (HTTP, WS, etc)
    long                      ret_code_library;                   ///< Library return code (curl, nopoll, etc)
    char                      server_ip[XRSR_SESSION_IP_LEN_MAX]; ///< NULL-terminated string indicating the server's IP address
    double                    time_connect;                       ///< Amount of time elapsed during server connection (in seconds)
    double                    time_dns;                           ///< Amount of time elapsed during DNS lookup (in seconds)
+   xrsr_stream_end_reason_t  stream_end_reason;                  ///< Reason why the stream ended
 } xrsr_session_stats_t;
 
 /// @brief XRSR stream stats structure

--- a/src/xr-speech-router/xrsr_protocol_http.c
+++ b/src/xr-speech-router/xrsr_protocol_http.c
@@ -757,6 +757,7 @@ void xrsr_http_reset(xrsr_state_http_t *http) {
         http->audio_src          = XRSR_SRC_INVALID;
         memset(&http->audio_stats, 0, sizeof(http->audio_stats));
         memset(&http->session_stats, 0, sizeof(http->session_stats));
+        http->session_stats.stream_end_reason = XRSR_STREAM_END_REASON_DID_NOT_BEGIN;
         http->detect_resume      = true;
         http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_EOS;
         http->is_session_by_text   = false;

--- a/src/xr-speech-router/xrsr_protocol_http.c
+++ b/src/xr-speech-router/xrsr_protocol_http.c
@@ -758,7 +758,7 @@ void xrsr_http_reset(xrsr_state_http_t *http) {
         memset(&http->audio_stats, 0, sizeof(http->audio_stats));
         memset(&http->session_stats, 0, sizeof(http->session_stats));
         http->detect_resume      = true;
-        http->session_stats.reason = XRSR_SESSION_END_REASON_EOS;
+        http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_EOS;
         http->is_session_by_text   = false;
         http->is_session_by_file   = false;
     }
@@ -803,7 +803,7 @@ void St_Http_Disconnected(tStateEvent *pEvent, eStateAction eAction, BOOL *bGuar
             if(http->handlers.disconnected == NULL) {
                 XLOGD_INFO("disconnected handler not available");
             } else {
-                (*http->handlers.disconnected)(http->handlers.data, http->uuid, http->session_stats.reason, false, &http->detect_resume, &timestamp);
+                (*http->handlers.disconnected)(http->handlers.data, http->uuid, http->session_stats.session_end_reason, false, &http->detect_resume, &timestamp);
             }
             char uuid_str[37] = {'\0'};
             uuid_unparse_lower(http->uuid, uuid_str);
@@ -831,12 +831,12 @@ void St_Http_Buffering(tStateEvent *pEvent, eStateAction eAction, BOOL *bGuardRe
             switch(pEvent->mID) {
                 case SM_EVENT_EOS: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_DID_NOT_BEGIN, http->detect_resume, &http->audio_stats);
-                    http->session_stats.reason = XRSR_SESSION_END_REASON_ERROR_AUDIO_DURATION;
+                    http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_ERROR_AUDIO_DURATION;
                     break;
                 }
                 case SM_EVENT_TERMINATE: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_DID_NOT_BEGIN, http->detect_resume, &http->audio_stats);
-                    http->session_stats.reason = XRSR_SESSION_END_REASON_TERMINATE;
+                    http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_TERMINATE;
                     break;
                 }
                 default: {
@@ -872,7 +872,7 @@ void St_Http_Connecting(tStateEvent *pEvent, eStateAction eAction, BOOL *bGuardR
             switch(pEvent->mID) {
                 case SM_EVENT_DISCONNECTED: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_DID_NOT_BEGIN, http->detect_resume, &http->audio_stats);
-                    http->session_stats.reason = XRSR_SESSION_END_REASON_ERROR_CONNECT_FAILURE;
+                    http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_ERROR_CONNECT_FAILURE;
                     break;
                 }
                 case SM_EVENT_CONNECTED: {
@@ -916,11 +916,11 @@ void St_Http_Connected(tStateEvent *pEvent, eStateAction eAction, BOOL *bGuardRe
         case ACT_EXIT: {
             switch(pEvent->mID) {
                 case SM_EVENT_TIMEOUT: {
-                    http->session_stats.reason = XRSR_SESSION_END_REASON_ERROR_SESSION_TIMEOUT;
+                    http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_ERROR_SESSION_TIMEOUT;
                     break;
                 }
                 case SM_EVENT_TERMINATE: {
-                    http->session_stats.reason = XRSR_SESSION_END_REASON_TERMINATE;
+                    http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_TERMINATE;
                     break;
                 }
                 default: {
@@ -965,12 +965,12 @@ void St_Http_Streaming(tStateEvent *pEvent, eStateAction eAction, BOOL *bGuardRe
             switch(pEvent->mID) {
                 case SM_EVENT_TERMINATE: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_DISCONNECT_LOCAL, http->detect_resume, &http->audio_stats);
-                    http->session_stats.reason = XRSR_SESSION_END_REASON_TERMINATE;
+                    http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_TERMINATE;
                     break;
                 }
                 case SM_EVENT_MSG_RECV: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_DISCONNECT_REMOTE, http->detect_resume, &http->audio_stats);
-                    http->session_stats.reason = XRSR_SESSION_END_REASON_ERROR_CONNECT_FAILURE;
+                    http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_ERROR_CONNECT_FAILURE;
                     break;
                 }
                 case SM_EVENT_PIPE_EOS: {
@@ -1009,12 +1009,12 @@ void St_Http_TextOnlySession(tStateEvent *pEvent, eStateAction eAction, BOOL *bG
             switch(pEvent->mID) {
                 case SM_EVENT_TERMINATE: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_DISCONNECT_LOCAL, http->detect_resume, &http->audio_stats);
-                    http->session_stats.reason = XRSR_SESSION_END_REASON_TERMINATE;
+                    http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_TERMINATE;
                     break;
                 }
                 case SM_EVENT_MSG_RECV: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_INVALID, http->detect_resume, &http->audio_stats);
-                    http->session_stats.reason = XRSR_SESSION_END_REASON_EOT;
+                    http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_EOT;
                     break;
                 }
                 case SM_EVENT_PIPE_EOS: {

--- a/src/xr-speech-router/xrsr_protocol_http.c
+++ b/src/xr-speech-router/xrsr_protocol_http.c
@@ -832,11 +832,13 @@ void St_Http_Buffering(tStateEvent *pEvent, eStateAction eAction, BOOL *bGuardRe
                 case SM_EVENT_EOS: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_DID_NOT_BEGIN, http->detect_resume, &http->audio_stats);
                     http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_ERROR_AUDIO_DURATION;
+                    http->session_stats.stream_end_reason = XRSR_STREAM_END_REASON_DID_NOT_BEGIN;
                     break;
                 }
                 case SM_EVENT_TERMINATE: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_DID_NOT_BEGIN, http->detect_resume, &http->audio_stats);
                     http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_TERMINATE;
+                    http->session_stats.stream_end_reason = XRSR_STREAM_END_REASON_DID_NOT_BEGIN;
                     break;
                 }
                 default: {
@@ -873,6 +875,7 @@ void St_Http_Connecting(tStateEvent *pEvent, eStateAction eAction, BOOL *bGuardR
                 case SM_EVENT_DISCONNECTED: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_DID_NOT_BEGIN, http->detect_resume, &http->audio_stats);
                     http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_ERROR_CONNECT_FAILURE;
+                    http->session_stats.stream_end_reason = XRSR_STREAM_END_REASON_DID_NOT_BEGIN;
                     break;
                 }
                 case SM_EVENT_CONNECTED: {
@@ -966,15 +969,18 @@ void St_Http_Streaming(tStateEvent *pEvent, eStateAction eAction, BOOL *bGuardRe
                 case SM_EVENT_TERMINATE: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_DISCONNECT_LOCAL, http->detect_resume, &http->audio_stats);
                     http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_TERMINATE;
+                    http->session_stats.stream_end_reason = XRSR_STREAM_END_REASON_DISCONNECT_LOCAL;
                     break;
                 }
                 case SM_EVENT_MSG_RECV: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_DISCONNECT_REMOTE, http->detect_resume, &http->audio_stats);
                     http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_ERROR_CONNECT_FAILURE;
+                    http->session_stats.stream_end_reason = XRSR_STREAM_END_REASON_DISCONNECT_REMOTE;
                     break;
                 }
                 case SM_EVENT_PIPE_EOS: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_AUDIO_EOF, http->detect_resume, &http->audio_stats);
+                    http->session_stats.stream_end_reason = XRSR_STREAM_END_REASON_AUDIO_EOF;
                     break;
                 }
                 case SM_EVENT_TEXT_SESSION_SUCCESS: {
@@ -1010,15 +1016,18 @@ void St_Http_TextOnlySession(tStateEvent *pEvent, eStateAction eAction, BOOL *bG
                 case SM_EVENT_TERMINATE: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_DISCONNECT_LOCAL, http->detect_resume, &http->audio_stats);
                     http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_TERMINATE;
+                    http->session_stats.stream_end_reason = XRSR_STREAM_END_REASON_DISCONNECT_LOCAL;
                     break;
                 }
                 case SM_EVENT_MSG_RECV: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_INVALID, http->detect_resume, &http->audio_stats);
                     http->session_stats.session_end_reason = XRSR_SESSION_END_REASON_EOT;
+                    http->session_stats.stream_end_reason = XRSR_STREAM_END_REASON_INVALID;
                     break;
                 }
                 case SM_EVENT_PIPE_EOS: {
                     xrsr_speech_stream_end(http->uuid, http->audio_src, http->dst_index, XRSR_STREAM_END_REASON_AUDIO_EOF, http->detect_resume, &http->audio_stats);
+                    http->session_stats.stream_end_reason = XRSR_STREAM_END_REASON_AUDIO_EOF;
                     break;
                 }
                 default: {

--- a/src/xr-speech-router/xrsr_protocol_sdt.c
+++ b/src/xr-speech-router/xrsr_protocol_sdt.c
@@ -200,6 +200,7 @@ bool xrsr_sdt_connect(xrsr_state_sdt_t *sdt, xrsr_url_parts_t *url_parts, xrsr_s
    sdt->on_close           = false;
    memset(&sdt->stats, 0, sizeof(sdt->stats));
    memset(&sdt->audio_stats, 0, sizeof(sdt->audio_stats));
+   sdt->stats.stream_end_reason = XRSR_STREAM_END_REASON_DID_NOT_BEGIN;
 
    if(!deferred) {
       xrsr_sdt_event(sdt, SM_EVENT_SESSION_BEGIN, false);

--- a/src/xr-speech-router/xrsr_protocol_sdt.c
+++ b/src/xr-speech-router/xrsr_protocol_sdt.c
@@ -400,6 +400,8 @@ void xrsr_sdt_reset(xrsr_state_sdt_t *sdt) {
       sdt->detect_resume         = true;
       sdt->on_close              = false;
       sdt->retry_cnt             = 1;
+      memset(&sdt->stats, 0, sizeof(sdt->stats));
+      sdt->stats.stream_end_reason = XRSR_STREAM_END_REASON_DID_NOT_BEGIN;
       if(sdt->audio_pipe_fd_read > -1) {
          close(sdt->audio_pipe_fd_read);
          sdt->audio_pipe_fd_read = -1;

--- a/src/xr-speech-router/xrsr_protocol_sdt.c
+++ b/src/xr-speech-router/xrsr_protocol_sdt.c
@@ -312,8 +312,6 @@ int xrsr_sdt_send_text(xrsr_state_sdt_t *sdt, const uint8_t *buffer, uint32_t le
 void xrsr_sdt_speech_stream_end(xrsr_state_sdt_t *sdt, xrsr_stream_end_reason_t reason, bool detect_resume) {
    XLOGD_INFO("fd <%d> reason <%s>", sdt->audio_pipe_fd_read, xrsr_stream_end_reason_str(reason));
 
-   sdt->stats.stream_end_reason = reason;
-
    xrsr_speech_stream_end(sdt->uuid, sdt->audio_src, sdt->dst_index, reason, detect_resume, &sdt->audio_stats);
 
    if(sdt->audio_pipe_fd_read >= 0) {

--- a/src/xr-speech-router/xrsr_protocol_sdt.c
+++ b/src/xr-speech-router/xrsr_protocol_sdt.c
@@ -313,6 +313,7 @@ void xrsr_sdt_speech_stream_end(xrsr_state_sdt_t *sdt, xrsr_stream_end_reason_t 
    XLOGD_INFO("fd <%d> reason <%s>", sdt->audio_pipe_fd_read, xrsr_stream_end_reason_str(reason));
 
    xrsr_speech_stream_end(sdt->uuid, sdt->audio_src, sdt->dst_index, reason, detect_resume, &sdt->audio_stats);
+   sdt->stats.stream_end_reason = reason;
 
    if(sdt->audio_pipe_fd_read >= 0) {
       close(sdt->audio_pipe_fd_read);

--- a/src/xr-speech-router/xrsr_protocol_sdt.c
+++ b/src/xr-speech-router/xrsr_protocol_sdt.c
@@ -312,6 +312,8 @@ int xrsr_sdt_send_text(xrsr_state_sdt_t *sdt, const uint8_t *buffer, uint32_t le
 void xrsr_sdt_speech_stream_end(xrsr_state_sdt_t *sdt, xrsr_stream_end_reason_t reason, bool detect_resume) {
    XLOGD_INFO("fd <%d> reason <%s>", sdt->audio_pipe_fd_read, xrsr_stream_end_reason_str(reason));
 
+   sdt->stats.stream_end_reason = reason;
+
    xrsr_speech_stream_end(sdt->uuid, sdt->audio_src, sdt->dst_index, reason, detect_resume, &sdt->audio_stats);
 
    if(sdt->audio_pipe_fd_read >= 0) {
@@ -323,7 +325,7 @@ void xrsr_sdt_speech_stream_end(xrsr_state_sdt_t *sdt, xrsr_stream_end_reason_t 
 void xrsr_sdt_speech_session_end(xrsr_state_sdt_t *sdt, xrsr_session_end_reason_t reason) {
    XLOGD_INFO("fd <%d> reason <%s>", sdt->audio_pipe_fd_read, xrsr_session_end_reason_str(reason));
 
-   sdt->stats.reason = reason;
+   sdt->stats.session_end_reason = reason;
 
    char uuid_str[37] = {'\0'};
    uuid_unparse_lower(sdt->uuid, uuid_str);

--- a/src/xr-speech-router/xrsr_protocol_ws.c
+++ b/src/xr-speech-router/xrsr_protocol_ws.c
@@ -955,6 +955,7 @@ void St_Ws_Disconnecting(tStateEvent *pEvent, eStateAction eAction, BOOL *bGuard
             // only call close if network is available
             XLOG_DEBUG("src <%s> nopoll ref count %d, should be 2...", xrsr_src_str(ws->audio_src), nopoll_conn_ref_count(ws->obj_conn));
             if(ws->on_close == false) {
+               ws->close_status = nopoll_conn_get_close_status(conn);
                nopoll_conn_close(ws->obj_conn);
             } else {
                XLOG_DEBUG("src <%s> server closed the connection", xrsr_src_str(ws->audio_src));

--- a/src/xr-speech-router/xrsr_protocol_ws.c
+++ b/src/xr-speech-router/xrsr_protocol_ws.c
@@ -955,7 +955,7 @@ void St_Ws_Disconnecting(tStateEvent *pEvent, eStateAction eAction, BOOL *bGuard
             // only call close if network is available
             XLOG_DEBUG("src <%s> nopoll ref count %d, should be 2...", xrsr_src_str(ws->audio_src), nopoll_conn_ref_count(ws->obj_conn));
             if(ws->on_close == false) {
-               ws->close_status = nopoll_conn_get_close_status(conn);
+               ws->close_status = nopoll_conn_get_close_status(ws->obj_conn);
                nopoll_conn_close(ws->obj_conn);
             } else {
                XLOG_DEBUG("src <%s> server closed the connection", xrsr_src_str(ws->audio_src));

--- a/src/xr-speech-router/xrsr_protocol_ws.c
+++ b/src/xr-speech-router/xrsr_protocol_ws.c
@@ -739,8 +739,6 @@ void xrsr_ws_on_close(noPollCtx *ctx, noPollConn *conn, noPollPtr user_data) {
 void xrsr_ws_speech_stream_end(xrsr_state_ws_t *ws, xrsr_stream_end_reason_t reason, bool detect_resume) {
    XLOGD_INFO("src <%s> fd <%d> reason <%s>", xrsr_src_str(ws->audio_src), ws->audio_pipe_fd_read, xrsr_stream_end_reason_str(reason));
 
-   ws->stats.stream_end_reason = reason;
-
    xrsr_speech_stream_end(ws->uuid, ws->audio_src, ws->dst_index, reason, detect_resume, &ws->audio_stats);
 
    if(ws->audio_pipe_fd_read >= 0) {

--- a/src/xr-speech-router/xrsr_protocol_ws.c
+++ b/src/xr-speech-router/xrsr_protocol_ws.c
@@ -739,6 +739,8 @@ void xrsr_ws_on_close(noPollCtx *ctx, noPollConn *conn, noPollPtr user_data) {
 void xrsr_ws_speech_stream_end(xrsr_state_ws_t *ws, xrsr_stream_end_reason_t reason, bool detect_resume) {
    XLOGD_INFO("src <%s> fd <%d> reason <%s>", xrsr_src_str(ws->audio_src), ws->audio_pipe_fd_read, xrsr_stream_end_reason_str(reason));
 
+   ws->stats.stream_end_reason = reason;
+
    xrsr_speech_stream_end(ws->uuid, ws->audio_src, ws->dst_index, reason, detect_resume, &ws->audio_stats);
 
    if(ws->audio_pipe_fd_read >= 0) {
@@ -750,7 +752,7 @@ void xrsr_ws_speech_stream_end(xrsr_state_ws_t *ws, xrsr_stream_end_reason_t rea
 void xrsr_ws_speech_session_end(xrsr_state_ws_t *ws, xrsr_session_end_reason_t reason) {
    XLOGD_INFO("src <%s> fd <%d> reason <%s> close code <%d>", xrsr_src_str(ws->audio_src), ws->audio_pipe_fd_read, xrsr_session_end_reason_str(reason), ws->close_status);
 
-   ws->stats.reason = reason;
+   ws->stats.session_end_reason = reason;
 
    char uuid_str[37] = {'\0'};
    uuid_unparse_lower(ws->uuid, uuid_str);

--- a/src/xr-speech-router/xrsr_protocol_ws.c
+++ b/src/xr-speech-router/xrsr_protocol_ws.c
@@ -740,6 +740,7 @@ void xrsr_ws_speech_stream_end(xrsr_state_ws_t *ws, xrsr_stream_end_reason_t rea
    XLOGD_INFO("src <%s> fd <%d> reason <%s>", xrsr_src_str(ws->audio_src), ws->audio_pipe_fd_read, xrsr_stream_end_reason_str(reason));
 
    xrsr_speech_stream_end(ws->uuid, ws->audio_src, ws->dst_index, reason, detect_resume, &ws->audio_stats);
+   ws->stats.stream_end_reason = reason;
 
    if(ws->audio_pipe_fd_read >= 0) {
       close(ws->audio_pipe_fd_read);

--- a/src/xr-speech-router/xrsr_protocol_ws.c
+++ b/src/xr-speech-router/xrsr_protocol_ws.c
@@ -753,6 +753,7 @@ void xrsr_ws_speech_session_end(xrsr_state_ws_t *ws, xrsr_session_end_reason_t r
    XLOGD_INFO("src <%s> fd <%d> reason <%s> close code <%d>", xrsr_src_str(ws->audio_src), ws->audio_pipe_fd_read, xrsr_session_end_reason_str(reason), ws->close_status);
 
    ws->stats.session_end_reason = reason;
+   ws->stats.ret_code_protocol = ws->close_status;
 
    char uuid_str[37] = {'\0'};
    uuid_unparse_lower(ws->uuid, uuid_str);

--- a/src/xr-speech-router/xrsr_protocol_ws.c
+++ b/src/xr-speech-router/xrsr_protocol_ws.c
@@ -453,6 +453,7 @@ bool xrsr_ws_connect(xrsr_state_ws_t *ws, xrsr_url_parts_t *url_parts, xrsr_src_
    ws->close_status       = -1;
    memset(&ws->stats, 0, sizeof(ws->stats));
    memset(&ws->audio_stats, 0, sizeof(ws->audio_stats));
+   ws->stats.stream_end_reason = XRSR_STREAM_END_REASON_DID_NOT_BEGIN;
 
    if(!deferred) {
       xrsr_ws_event(ws, SM_EVENT_SESSION_BEGIN, false);

--- a/src/xr-speech-router/xrsr_protocol_ws.c
+++ b/src/xr-speech-router/xrsr_protocol_ws.c
@@ -883,6 +883,7 @@ void xrsr_ws_reset(xrsr_state_ws_t *ws) {
          close(ws->audio_pipe_fd_read);
          ws->audio_pipe_fd_read = -1;
       }
+      memset(&ws->stats, 0, sizeof(ws->stats));
       xrsr_ws_clear_msg_out(ws);
    }
 }

--- a/src/xr-speech-router/xrsr_protocol_ws.c
+++ b/src/xr-speech-router/xrsr_protocol_ws.c
@@ -884,6 +884,7 @@ void xrsr_ws_reset(xrsr_state_ws_t *ws) {
          ws->audio_pipe_fd_read = -1;
       }
       memset(&ws->stats, 0, sizeof(ws->stats));
+      ws->stats.stream_end_reason = XRSR_STREAM_END_REASON_DID_NOT_BEGIN;
       xrsr_ws_clear_msg_out(ws);
    }
 }


### PR DESCRIPTION
Reason for change: Better telemetry for session failures

Test Procedure: check telemetry for new fields, confirm they are correct values

Priority: P0