### PR TITLE
RDKEMW-23374: toggling privacy mode can cause ctrlm crash

### DIFF
--- a/src/xr-audio/xraudio_thread.c
+++ b/src/xr-audio/xraudio_thread.c
@@ -2095,7 +2095,8 @@ void xraudio_msg_privacy_mode(xraudio_thread_state_t *state, void *msg) {
 
    xraudio_result_t result = XRAUDIO_RESULT_OK;
    // Call HAL to enter the privacy mode
-   if(state->params.kwd_plugin != NULL && !state->params.hal_plugin->privacy_mode(state->params.hal_obj, privacy_mode->enable)) {
+
+   if(state->params.kwd_plugin != NULL && state->record.recording && !state->params.hal_plugin->privacy_mode(state->params.hal_obj, privacy_mode->enable)) {
       result = XRAUDIO_RESULT_ERROR_INTERNAL;
    }
 

--- a/src/xr-speech-router/xrsr.c
+++ b/src/xr-speech-router/xrsr.c
@@ -674,7 +674,7 @@ bool xrsr_threads_init(bool is_prod) {
    // Launch threads
    xrsr_thread_info_t *info;
    info             = &g_xrsr.threads[XRSR_THREAD_MAIN];
-   info->name       = "main";
+   info->name       = "Voice SDK";
    info->msgq_id    = -1;
    info->msgsize    = XRSR_MSG_QUEUE_MSG_SIZE_MAX;
    info->func       = xrsr_thread_main;

--- a/src/xr-speech-router/xrsr_xraudio.c
+++ b/src/xr-speech-router/xrsr_xraudio.c
@@ -568,9 +568,6 @@ void xrsr_xraudio_keyword_detect_error(xrsr_xraudio_object_t object, xraudio_dev
       return;
    }
 
-   // Stop the detector
-   xrsr_xraudio_keyword_detect_stop(obj);
-
    // Call the appropriate handler based on the source
    xrsr_keyword_detect_error(src);
 
@@ -583,11 +580,6 @@ void xrsr_xraudio_keyword_detect_error(xrsr_xraudio_object_t object, xraudio_dev
       #else
       xrsr_xraudio_device_granted(obj);
       #endif
-   }
-
-   // TODO Should the app determine what to do here?
-   if(obj->detect_active) { // Start detector again
-      xrsr_xraudio_keyword_detect_start(obj);
    }
 }
 


### PR DESCRIPTION
Reason for change: We don't want to crash ctrlm

Test Procedure: using side panel button or UI toggle privacy mode repeatedly. Check ctrlm_log.txt for
"XRSR : xrsr_xraudio_keyword_detect_error: source " which indicates that an error occurred.
From there, confirm that the HAL is reloaded, state recovers, ctrlm does not crash

Risks: Low