### PR TITLE
RDKEMW-23374: restarting microphone HAL upon error detection

### DIFF
--- a/src/xr-audio/xraudio_thread.c
+++ b/src/xr-audio/xraudio_thread.c
@@ -1936,12 +1936,7 @@ void xraudio_msg_detect_stop(xraudio_thread_state_t *state, void *msg) {
 
    xraudio_keyword_detector_t *detector = &state->record.keyword_detector;
 
-   bool privacy_mode = false;
-   if(!state->params.hal_plugin->privacy_mode_get(state->params.hal_obj, &privacy_mode)) {
-      XLOGD_ERROR("failed to get privacy mode, defaulting to ON");
-      privacy_mode = true;
-   }
-   if(!xraudio_keyword_detector_session_is_armed(detector) && !privacy_mode) {
+   if(!xraudio_keyword_detector_session_is_armed(detector)) {
       XLOGD_WARN("detector is not armed");
    } else {
       xraudio_keyword_detector_session_disarm(&state->params, detector);

--- a/src/xr-audio/xraudio_thread.c
+++ b/src/xr-audio/xraudio_thread.c
@@ -1936,7 +1936,12 @@ void xraudio_msg_detect_stop(xraudio_thread_state_t *state, void *msg) {
 
    xraudio_keyword_detector_t *detector = &state->record.keyword_detector;
 
-   if(!xraudio_keyword_detector_session_is_armed(detector)) {
+   bool privacy_mode = false;
+   if(!state->params.hal_plugin->privacy_mode_get(state->params.hal_obj, &privacy_mode)) {
+      XLOGD_ERROR("failed to get privacy mode, defaulting to ON");
+      privacy_mode = true;
+   }
+   if(!xraudio_keyword_detector_session_is_armed(detector) && !privacy_mode) {
       XLOGD_WARN("detector is not armed");
    } else {
       xraudio_keyword_detector_session_disarm(&state->params, detector);

--- a/src/xr-speech-router/xrsr_xraudio.c
+++ b/src/xr-speech-router/xrsr_xraudio.c
@@ -465,7 +465,7 @@ static void xrsr_xraudio_keyword_detect_start(xrsr_xraudio_obj_t *obj) {
    }
 }
 
-void xrsr_xraudio_keyword_detect_stop(xrsr_xraudio_obj_t *obj) {
+static void xrsr_xraudio_keyword_detect_stop(xrsr_xraudio_obj_t *obj) {
    xrsr_xraudio_stream_t *stream = &obj->xraudio_streams[XRSR_SESSION_GROUP_DEFAULT];
 
    if(!stream->detecting) { // already stopped

--- a/src/xr-speech-router/xrsr_xraudio.c
+++ b/src/xr-speech-router/xrsr_xraudio.c
@@ -382,11 +382,9 @@ void xrsr_xraudio_device_close(xrsr_xraudio_object_t object) {
          xraudio_stream_stop(obj->xraudio_obj, device, -1);
          stream->active = false;
       }
-      if(stream->detecting) {
-         xraudio_detect_stop(obj->xraudio_obj);
-         stream->detecting = false;
-      }
    }
+
+   xrsr_xraudio_keyword_detect_stop(obj);
 
    if(obj->xraudio_state == XRSR_XRAUDIO_STATE_OPENED) {
       xraudio_close(obj->xraudio_obj);
@@ -436,13 +434,17 @@ void xrsr_xraudio_keyword_detect_restart(xrsr_xraudio_object_t object) {
 }
 
 void xrsr_xraudio_keyword_detect_start(xrsr_xraudio_obj_t *obj) {
+   xrsr_xraudio_stream_t *stream = &obj->xraudio_streams[XRSR_SESSION_GROUP_DEFAULT];
+
+   if(stream->detecting) { // already armed
+      return;
+   }
+
    if(obj->default_sensitivity) {
       XLOGD_INFO("sensitivity <default>");
    } else {
       XLOGD_INFO("sensitivity <%f>", obj->keyword_sensitivity);
    }
-
-   xrsr_xraudio_stream_t *stream = &obj->xraudio_streams[XRSR_SESSION_GROUP_DEFAULT];
 
    xraudio_result_t result = xraudio_detect_params(obj->xraudio_obj, obj->default_sensitivity ? NULL : &obj->keyword_sensitivity);
    if(XRAUDIO_RESULT_OK != result) {
@@ -464,6 +466,13 @@ void xrsr_xraudio_keyword_detect_start(xrsr_xraudio_obj_t *obj) {
 }
 
 void xrsr_xraudio_keyword_detect_stop(xrsr_xraudio_obj_t *obj) {
+   xrsr_xraudio_stream_t *stream = &obj->xraudio_streams[XRSR_SESSION_GROUP_DEFAULT];
+
+   if(!stream->detecting) { // already stopped
+      return;
+   }
+   stream->detecting = false;
+
    xraudio_result_t result = xraudio_detect_stop(obj->xraudio_obj);
 
    if(result != XRAUDIO_RESULT_OK) {
@@ -805,10 +814,7 @@ bool xrsr_xraudio_session_request(xrsr_xraudio_object_t object, xrsr_src_t src, 
    }
 
    if(src != XRSR_SRC_MICROPHONE_TAP) {
-      xrsr_xraudio_stream_t *stream = &obj->xraudio_streams[XRSR_SESSION_GROUP_DEFAULT];
-      if(stream->detecting) {
-         xraudio_detect_stop(obj->xraudio_obj);
-      }
+      xrsr_xraudio_keyword_detect_stop(obj);
    }
 
    if(input_format.type == XRSR_SESSION_REQUEST_TYPE_AUDIO_FD) { // Set the audio input format and file descriptor (even if not available yet)

--- a/src/xr-speech-router/xrsr_xraudio.c
+++ b/src/xr-speech-router/xrsr_xraudio.c
@@ -433,7 +433,7 @@ void xrsr_xraudio_keyword_detect_restart(xrsr_xraudio_object_t object) {
    xrsr_xraudio_keyword_detect_start(obj);
 }
 
-void xrsr_xraudio_keyword_detect_start(xrsr_xraudio_obj_t *obj) {
+static void xrsr_xraudio_keyword_detect_start(xrsr_xraudio_obj_t *obj) {
    xrsr_xraudio_stream_t *stream = &obj->xraudio_streams[XRSR_SESSION_GROUP_DEFAULT];
 
    if(stream->detecting) { // already armed

--- a/src/xr-speech-router/xrsr_xraudio.c
+++ b/src/xr-speech-router/xrsr_xraudio.c
@@ -471,6 +471,7 @@ static void xrsr_xraudio_keyword_detect_stop(xrsr_xraudio_obj_t *obj) {
    if(!stream->detecting) { // already stopped
       return;
    }
+   stream->detecting = false;
 
    xraudio_result_t result = xraudio_detect_stop(obj->xraudio_obj);
 
@@ -479,7 +480,6 @@ static void xrsr_xraudio_keyword_detect_stop(xrsr_xraudio_obj_t *obj) {
        return;
    }
    obj->xraudio_state = XRSR_XRAUDIO_STATE_OPENED;
-   stream->detecting = false;
   
 }
 

--- a/src/xr-speech-router/xrsr_xraudio.c
+++ b/src/xr-speech-router/xrsr_xraudio.c
@@ -471,7 +471,6 @@ static void xrsr_xraudio_keyword_detect_stop(xrsr_xraudio_obj_t *obj) {
    if(!stream->detecting) { // already stopped
       return;
    }
-   stream->detecting = false;
 
    xraudio_result_t result = xraudio_detect_stop(obj->xraudio_obj);
 
@@ -480,6 +479,8 @@ static void xrsr_xraudio_keyword_detect_stop(xrsr_xraudio_obj_t *obj) {
        return;
    }
    obj->xraudio_state = XRSR_XRAUDIO_STATE_OPENED;
+   stream->detecting = false;
+  
 }
 
 void xrsr_xraudio_keyword_detected(xrsr_xraudio_object_t object, xrsr_queue_msg_keyword_detected_t *msg, xrsr_src_t current_session_src, bool requested_more_audio, bool *audio_stream_start) {


### PR DESCRIPTION
Reason for change: The local mics interface can be restarted in case of errors. Here the voice SDK could stop and restart keyword detection more than once, which is a state handling error. I have moved the check for detecting to a single point in xrsr_xraudio_keyword_detect_stop()
Also SDK will not call xraudio_msg_detect_stop() when the input is muted.

Test Procedure: the ticket says that if you use the UI or side panel privacy button to enter and exist privacy mode repeatedly then the HAL will crash which causes Control Manager to crash. Now the HAL will crash, and the voice SDK will restart the HAL with no Control Manager crash